### PR TITLE
Fix for TP3 to allow the icon to display correctly in the Detailed Views

### DIFF
--- a/data/index.js
+++ b/data/index.js
@@ -45,8 +45,8 @@ var attachEntity = function () {
     }));
 
     // Add the button to the page
-    var el = document.getElementsByClassName('view-header__link')[0];
-    el.parentNode.insertBefore(div, el);
+    var el = document.getElementsByClassName('view-header__name')[0];
+    el.parentNode.appendChild(div);
 
     // Tell Harvest a new timer was added
     if (document.querySelector("#harvest-messaging")) {


### PR DESCRIPTION
Fix to appendChild to the `view-header__name` class which is still available with the new Detail Views and also works with the old Detail Views as well.

They removed the `view-header__link` and moved what was using that class to the upper right corner which there aren't any classes to hook onto like it was before. `view-header__name` is the only thing that can be hooked onto to keep the same location as it was before.

**Old Detail View:**
<img width="746" alt="Screen Shot 2020-01-03 at 2 56 29 PM" src="https://user-images.githubusercontent.com/636531/71745854-60c8b000-2e39-11ea-9f30-dcaf298b7da9.png">

**New Detail View:**
<img width="723" alt="Screen Shot 2020-01-03 at 2 56 24 PM" src="https://user-images.githubusercontent.com/636531/71745860-6625fa80-2e39-11ea-9815-9693de2d4a01.png">
